### PR TITLE
Support --dotfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.0.0-beta.2
+## Support --dotfiles
+
+- `--dotfiles` flag defaulting to `false` is now supported, similarly to [gh-pages](https://www.npmjs.com/package/gh-pages#optionsdotfiles), to support deploying pages which need dotfiles to function correctly
+
 # v1.0.0-beta.1
 ## Deploy to root on `master` branch
 

--- a/bin/deploy-to-github-pages.js
+++ b/bin/deploy-to-github-pages.js
@@ -13,6 +13,7 @@ async function main() {
     .option('-r, --repo [repo]', 'GitHub repo name')
     .option('-b, --branch [branch]', 'Branch name')
     .option('-u, --build-url [build-url]', 'Link displayed when deployment fails')
+    .option('--dotfiles', 'Include dotfiles')
     .parse(process.argv);
 
   const options = cleanOptions({
@@ -22,6 +23,7 @@ async function main() {
     repo: program.repo,
     branch: program.branch,
     buildUrl: program.buildUrl,
+    dotfiles: !!program.dotfiles,
   });
 
   try {

--- a/lib/deployment/pages/pages.js
+++ b/lib/deployment/pages/pages.js
@@ -10,11 +10,12 @@ async function deployDirectoryToGithubPages(directory, options) {
   }
 }
 
-function deploy(directory, { token, owner, repo }) {
+function deploy(directory, { token, owner, repo, dotfiles }) {
   const params = {
     add: true,
     repo: `https://${token}@github.com/${owner}/${repo}.git`,
     silent: true,
+    dotfiles,
   };
 
   return new Promise((resolve, reject) => {

--- a/lib/deployment/pages/pages.spec.js
+++ b/lib/deployment/pages/pages.spec.js
@@ -5,7 +5,7 @@ const { deployDirectoryToGithubPages } = require('./');
 jest.mock('gh-pages');
 
 describe('Github pages', () => {
-  it('deploys to gh-pages with token', async () => {
+  it('deploys to gh-pages with correct options', async () => {
     expect.assertions(2);
     mockPublishForCallbackArgument(undefined);
 
@@ -13,12 +13,18 @@ describe('Github pages', () => {
       token: 'a-token',
       owner: 'an-owner',
       repo: 'a-repo',
+      dotfiles: true,
     };
     expect(ghpages.publish).not.toBeCalled();
     await deployDirectoryToGithubPages('a-directory', options);
     expect(ghpages.publish).toBeCalledWith(
       'a-directory',
-      { add: true, repo: 'https://a-token@github.com/an-owner/a-repo.git', silent: true },
+      {
+        add: true,
+        repo: 'https://a-token@github.com/an-owner/a-repo.git',
+        silent: true,
+        dotfiles: true,
+      },
       expect.any(Function),
     );
   });

--- a/lib/options/options.js
+++ b/lib/options/options.js
@@ -15,7 +15,7 @@ function extendPassedOptions(options) {
 }
 
 function extendWithDefaultOptions(options) {
-  return { directory: 'public', branch: 'master', ...options };
+  return { directory: 'public', branch: 'master', dotfiles: false, ...options };
 }
 
 function extendWithGithubTokenVariable(options) {

--- a/lib/options/options.spec.js
+++ b/lib/options/options.spec.js
@@ -3,13 +3,18 @@ const { createOptions } = require('./');
 describe('Options', () => {
   beforeEach(cleanEnvironmentVariables);
 
-  it('extends passed options with default directory to deploy and master branch', () => {
+  it('extends passed options with default directory to deploy, master branch, and no dotfiles', () => {
     const options = {
       token: 'a-token',
       owner: 'an-owner',
       repo: 'a-repo',
     };
-    expect(createOptions(options)).toEqual({ ...options, directory: 'public', branch: 'master' });
+    expect(createOptions(options)).toEqual({
+      ...options,
+      directory: 'public',
+      branch: 'master',
+      dotfiles: false,
+    });
   });
 
   it('prefers passed options to default options', () => {
@@ -19,6 +24,7 @@ describe('Options', () => {
       repo: 'a-repo',
       branch: 'a-branch',
       directory: 'a-directory',
+      dotfiles: true,
     };
     expect(createOptions(options)).toEqual(options);
   });
@@ -31,6 +37,7 @@ describe('Options', () => {
       repo: 'a-repo',
       branch: 'a-branch',
       directory: 'a-directory',
+      dotfiles: true,
     };
     expect(createOptions(options)).toEqual({ ...options, token: 'a-token' });
   });
@@ -51,6 +58,7 @@ describe('Options', () => {
       branch: 'a-branch',
       buildUrl: '/a-build-url',
       directory: 'a-directory',
+      dotfiles: false,
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deploy-to-github-pages",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A Node library that makes deploying a directory on a branch to GitHub pages easy and automatic.",
   "bin": {
     "deploy-to-github-pages": "bin/deploy-to-github-pages.js"


### PR DESCRIPTION
# v1.0.0-beta.2
## Support --dotfiles

- `--dotfiles` flag defaulting to `false` is now supported, similarly to [gh-pages](https://www.npmjs.com/package/gh-pages#optionsdotfiles), to support deploying pages which need dotfiles to function correctly