### PR TITLE
Get options from GitHub Actions environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.0.0-beta.3
+## Get options from GitHub Actions environments
+
+Only `directory` and `token` options are now required when running in [GitHub Actions](https://help.github.com/en/actions) workflows, similarly to CircleCI.
+
 # v1.0.0-beta.2
 ## Support --dotfiles
 

--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ deploy(options).catch(err => { console.log(err); })
 
 ### Options
 
-| Option      | flag  | description                                        | default    | env variable   | required | required with CircleCI |
-|-------------|------:|----------------------------------------------------|------------|----------------|---------:|-----------------------:|
-| `directory` |    -d | directory you wish to deploy                       | `'public'` |                |        * |                      * |
-| `token`     |    -t | [GitHub token](https://github.com/settings/tokens) |            | `GITHUB_TOKEN` |        * |                      * |
-| `owner`     |    -o | GitHub repo owner/org                              |            |                |        * |                        |
-| `repo`      |    -r | GitHub repo name                                   |            |                |        * |                        |
-| `branch`    |    -b | branch name                                        | `'master'` |                |        * |                        |
-| `buildUrl`  |    -u | link displayed when deployment fails               |            |                |          |                        |
+| Option      | flag  | description                                        | default    | env variable   | required | required in CI |
+|-------------|------:|----------------------------------------------------|------------|----------------|---------:|---------------:|
+| `directory` |    -d | directory you wish to deploy                       | `'public'` |                |        * |              * |
+| `token`     |    -t | [GitHub token](https://github.com/settings/tokens) |            | `GITHUB_TOKEN` |        * |              * |
+| `owner`     |    -o | GitHub repo owner/org                              |            |                |        * |                |
+| `repo`      |    -r | GitHub repo name                                   |            |                |        * |                |
+| `branch`    |    -b | branch name                                        | `'master'` |                |        * |                |
+| `buildUrl`  |    -u | link displayed when deployment fails               |            |                |          |                |
 
-Therefore, if ran from CircleCI with a `GITHUB_TOKEN` environment variable present and the directory to be deployed is named `public`, _no configuration options are needed_, so just the following is enough:
+Therefore, if ran from CircleCI or GitHub Actions workflows with a `GITHUB_TOKEN` environment variable present and the directory to be deployed is named `public`, _no configuration options are needed_, so just the following is enough:
 
 ```bash
 deploy-to-github-pages

--- a/lib/options/options.js
+++ b/lib/options/options.js
@@ -10,7 +10,9 @@ function createOptions(passedOptions) {
 
 function extendPassedOptions(options) {
   return extendWithDefaultOptions(
-    extendWithGithubTokenVariable(extendWithCircleVariablesIfCircle(options)),
+    extendWithGithubTokenVariable(
+      extendWithCircleVariablesIfCircle(extendWithGithubActionsVariablesIfGithubActions(options)),
+    ),
   );
 }
 
@@ -20,6 +22,25 @@ function extendWithDefaultOptions(options) {
 
 function extendWithGithubTokenVariable(options) {
   return process.env.GITHUB_TOKEN ? { token: process.env.GITHUB_TOKEN, ...options } : options;
+}
+
+function extendWithGithubActionsVariablesIfGithubActions(options) {
+  if (!process.env.GITHUB_WORKFLOW) {
+    return options;
+  }
+
+  const [owner, ...repoParts] = process.env.GITHUB_REPOSITORY.split('/');
+  const repo = repoParts.join('/');
+  const branch = process.env.GITHUB_REF.replace('refs/heads/', '');
+  const buildUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+
+  return {
+    owner,
+    repo,
+    branch,
+    buildUrl,
+    ...options,
+  };
 }
 
 function extendWithCircleVariablesIfCircle(options) {

--- a/lib/options/options.spec.js
+++ b/lib/options/options.spec.js
@@ -60,6 +60,36 @@ describe('Options', () => {
       directory: 'a-directory',
       dotfiles: false,
     });
+
+    delete process.env.CIRCLECI;
+    delete process.env.CIRCLE_PROJECT_USERNAME;
+    delete process.env.CIRCLE_PROJECT_REPONAME;
+    delete process.env.CIRCLE_BRANCH;
+    delete process.env.CIRCLE_BUILD_URL;
+  });
+
+  it('extends passed options with github actions variables if github actions', () => {
+    process.env.GITHUB_WORKFLOW = 'Workflow name';
+    process.env.GITHUB_RUN_ID = '123456';
+    process.env.GITHUB_REPOSITORY = 'an-owner/a-repo/with-slash';
+    process.env.GITHUB_REF = 'refs/heads/a-branch/with-slash';
+
+    const options = { token: 'a-token', directory: 'a-directory' };
+
+    expect(createOptions(options)).toEqual({
+      token: 'a-token',
+      owner: 'an-owner',
+      repo: 'a-repo/with-slash',
+      branch: 'a-branch/with-slash',
+      buildUrl: 'https://github.com/an-owner/a-repo/with-slash/actions/runs/123456',
+      directory: 'a-directory',
+      dotfiles: false,
+    });
+
+    delete process.env.GITHUB_WORKFLOW;
+    delete process.env.GITHUB_RUN_ID;
+    delete process.env.GITHUB_REPOSITORY;
+    delete process.env.GITHUB_REF;
   });
 
   it('throws if any required option is missing', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deploy-to-github-pages",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "A Node library that makes deploying a directory on a branch to GitHub pages easy and automatic.",
   "bin": {
     "deploy-to-github-pages": "bin/deploy-to-github-pages.js"


### PR DESCRIPTION
# v1.0.0-beta.3
## Get options from GitHub Actions environments

Only `directory` and `token` options are now required when running in [GitHub Actions](https://help.github.com/en/actions) workflows, similarly to CircleCI.