### PR TITLE
Add --verbose flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.0.0-beta.4
+## Add --verbose flag
+
+- `--verbose` flag defaulting to `false` is added, which when set, configures `gh-pages` [`silent` property](https://www.npmjs.com/package/gh-pages#optionssilent) as `false`, logging more information.
+
 # v1.0.0-beta.3
 ## Get options from GitHub Actions environments
 

--- a/bin/deploy-to-github-pages.js
+++ b/bin/deploy-to-github-pages.js
@@ -14,6 +14,7 @@ async function main() {
     .option('-b, --branch [branch]', 'Branch name')
     .option('-u, --build-url [build-url]', 'Link displayed when deployment fails')
     .option('--dotfiles', 'Include dotfiles')
+    .option('--verbose', 'Log verbose information from gh-pages')
     .parse(process.argv);
 
   const options = cleanOptions({
@@ -24,6 +25,7 @@ async function main() {
     branch: program.branch,
     buildUrl: program.buildUrl,
     dotfiles: !!program.dotfiles,
+    verbose: !!program.verbose,
   });
 
   try {

--- a/lib/deployment/pages/pages.js
+++ b/lib/deployment/pages/pages.js
@@ -10,11 +10,11 @@ async function deployDirectoryToGithubPages(directory, options) {
   }
 }
 
-function deploy(directory, { token, owner, repo, dotfiles }) {
+function deploy(directory, { token, owner, repo, verbose, dotfiles }) {
   const params = {
     add: true,
     repo: `https://${token}@github.com/${owner}/${repo}.git`,
-    silent: true,
+    silent: !verbose,
     dotfiles,
   };
 

--- a/lib/deployment/pages/pages.spec.js
+++ b/lib/deployment/pages/pages.spec.js
@@ -14,6 +14,7 @@ describe('Github pages', () => {
       owner: 'an-owner',
       repo: 'a-repo',
       dotfiles: true,
+      verbose: true,
     };
     expect(ghpages.publish).not.toBeCalled();
     await deployDirectoryToGithubPages('a-directory', options);
@@ -22,7 +23,7 @@ describe('Github pages', () => {
       {
         add: true,
         repo: 'https://a-token@github.com/an-owner/a-repo.git',
-        silent: true,
+        silent: false,
         dotfiles: true,
       },
       expect.any(Function),

--- a/lib/options/options.js
+++ b/lib/options/options.js
@@ -17,7 +17,7 @@ function extendPassedOptions(options) {
 }
 
 function extendWithDefaultOptions(options) {
-  return { directory: 'public', branch: 'master', dotfiles: false, ...options };
+  return { directory: 'public', branch: 'master', dotfiles: false, verbose: false, ...options };
 }
 
 function extendWithGithubTokenVariable(options) {

--- a/lib/options/options.spec.js
+++ b/lib/options/options.spec.js
@@ -14,6 +14,7 @@ describe('Options', () => {
       directory: 'public',
       branch: 'master',
       dotfiles: false,
+      verbose: false,
     });
   });
 
@@ -25,6 +26,7 @@ describe('Options', () => {
       branch: 'a-branch',
       directory: 'a-directory',
       dotfiles: true,
+      verbose: true,
     };
     expect(createOptions(options)).toEqual(options);
   });
@@ -38,6 +40,7 @@ describe('Options', () => {
       branch: 'a-branch',
       directory: 'a-directory',
       dotfiles: true,
+      verbose: true,
     };
     expect(createOptions(options)).toEqual({ ...options, token: 'a-token' });
   });
@@ -59,6 +62,7 @@ describe('Options', () => {
       buildUrl: '/a-build-url',
       directory: 'a-directory',
       dotfiles: false,
+      verbose: false,
     });
 
     delete process.env.CIRCLECI;
@@ -84,6 +88,7 @@ describe('Options', () => {
       buildUrl: 'https://github.com/an-owner/a-repo/with-slash/actions/runs/123456',
       directory: 'a-directory',
       dotfiles: false,
+      verbose: false,
     });
 
     delete process.env.GITHUB_WORKFLOW;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deploy-to-github-pages",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "A Node library that makes deploying a directory on a branch to GitHub pages easy and automatic.",
   "bin": {
     "deploy-to-github-pages": "bin/deploy-to-github-pages.js"


### PR DESCRIPTION
# v1.0.0-beta.4
## Add --verbose flag

- `--verbose` flag defaulting to `false` is added, which when set, configures `gh-pages` [`silent` property](https://www.npmjs.com/package/gh-pages#optionssilent) as `false`, logging more information.