### PR TITLE
Add default branch flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,92 +1,76 @@
 # v1.0.0-beta.6
-
 ## Add --defaultBranch flag
 
 - when the `--defaultBranch` flag is passed, users can specify a different default branch other than master
 
 # v1.0.0-beta.5
-
 ## Log options when verbose
 
 - when the `--verbose` flag is passed, `options` will be logged as well on deployment failure
 
 # v1.0.0-beta.4
-
 ## Add --verbose flag
 
 - `--verbose` flag defaulting to `false` is added, which when set, configures `gh-pages` [`silent` property](https://www.npmjs.com/package/gh-pages#optionssilent) as `false`, logging more information.
 
 # v1.0.0-beta.3
-
 ## Get options from GitHub Actions environments
 
 Only `directory` and `token` options are now required when running in [GitHub Actions](https://help.github.com/en/actions) workflows, similarly to CircleCI.
 
 # v1.0.0-beta.2
-
 ## Support --dotfiles
 
 - `--dotfiles` flag defaulting to `false` is now supported, similarly to [gh-pages](https://www.npmjs.com/package/gh-pages#optionsdotfiles), to support deploying pages which need dotfiles to function correctly
 
 # v1.0.0-beta.1
-
 ## Deploy to root on `master` branch
 
 - when branch is `master`, the directory won't be deployed to `/branch/${branchName}`, but `/` instead, allowing consumers to only rely on this package and not need `gh-pages` in addition
 - default `branch` value of `master` is added
 
 # v0.2.8
-
 ## Fix deployment id error
 
 - deployment id was taken from the wrong field
 
 # v0.2.7
-
 ## Refactors
 
 - error on pulling gh-pages branch to directory is logged now
 
 # v0.2.6
-
 ## Use Object spread instead of Object.assign
 
 There is no change in library behaviour.
 
 # v0.2.5
-
 ## Updates dependencies
 
 # v0.2.4
-
 ## Adds index.html to deployment URL
 
 GitHub pages, if not root, do not automatically redirect to `index.html`.
 
 # v0.2.3
-
 ## Adds trailing slash to deployment URL
 
 GitHub pages sometimes had inconsistent behaviour without it.
 
 # v0.2.2
-
 ## Uses passed token to publish to gh-pages
 
 # v0.2.1
-
 ## Fixes CLI
 
 Command Line Interface directory (`bin/`) is now included in the published npm package.
 
 # v0.2.0
-
 ## Adds Command Line Interface
 
 The main functionality is now exposed as `deploy-directory-on-branch-to-gh-pages` command.
 
 # v0.1.0
-
 ## Initial release
 
 This release exposes the main functionality as the default `deploy` function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,71 +1,92 @@
+# v1.0.0-beta.6
+
+## Add --defaultBranch flag
+
+- when the `--defaultBranch` flag is passed, users can specify a different default branch other than master
+
 # v1.0.0-beta.5
+
 ## Log options when verbose
 
 - when the `--verbose` flag is passed, `options` will be logged as well on deployment failure
 
 # v1.0.0-beta.4
+
 ## Add --verbose flag
 
 - `--verbose` flag defaulting to `false` is added, which when set, configures `gh-pages` [`silent` property](https://www.npmjs.com/package/gh-pages#optionssilent) as `false`, logging more information.
 
 # v1.0.0-beta.3
+
 ## Get options from GitHub Actions environments
 
 Only `directory` and `token` options are now required when running in [GitHub Actions](https://help.github.com/en/actions) workflows, similarly to CircleCI.
 
 # v1.0.0-beta.2
+
 ## Support --dotfiles
 
 - `--dotfiles` flag defaulting to `false` is now supported, similarly to [gh-pages](https://www.npmjs.com/package/gh-pages#optionsdotfiles), to support deploying pages which need dotfiles to function correctly
 
 # v1.0.0-beta.1
+
 ## Deploy to root on `master` branch
 
 - when branch is `master`, the directory won't be deployed to `/branch/${branchName}`, but `/` instead, allowing consumers to only rely on this package and not need `gh-pages` in addition
 - default `branch` value of `master` is added
 
 # v0.2.8
+
 ## Fix deployment id error
 
 - deployment id was taken from the wrong field
 
 # v0.2.7
+
 ## Refactors
 
 - error on pulling gh-pages branch to directory is logged now
 
 # v0.2.6
+
 ## Use Object spread instead of Object.assign
 
 There is no change in library behaviour.
 
 # v0.2.5
+
 ## Updates dependencies
 
 # v0.2.4
+
 ## Adds index.html to deployment URL
 
 GitHub pages, if not root, do not automatically redirect to `index.html`.
 
 # v0.2.3
+
 ## Adds trailing slash to deployment URL
 
 GitHub pages sometimes had inconsistent behaviour without it.
 
 # v0.2.2
+
 ## Uses passed token to publish to gh-pages
 
 # v0.2.1
+
 ## Fixes CLI
 
 Command Line Interface directory (`bin/`) is now included in the published npm package.
 
 # v0.2.0
+
 ## Adds Command Line Interface
 
 The main functionality is now exposed as `deploy-directory-on-branch-to-gh-pages` command.
 
 # v0.1.0
+
 ## Initial release
 
 This release exposes the main functionality as the default `deploy` function.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A Node and CLI tool that makes deploying to GitHub pages **by branch** easy and automatic, best used as part of a CI process.
 
-On `master`, your directory will be deployed to your GitHub page root similarly to other libraries, such as the wonderful [`gh-pages`](https://www.npmjs.com/package/gh-pages).
+On `master` (or on your specified `defaultBranch`) your directory will be deployed to your GitHub page root similarly to other libraries, such as the wonderful [`gh-pages`](https://www.npmjs.com/package/gh-pages).
 On other branches, it'll be deployed under `/branch/${branchName}`, allowing your peers to QA your built docs/demos easily for better feedback.
 
 It also sends a status to a Pull request, if one exists:
@@ -33,19 +33,22 @@ deploy-to-github-pages [...options]
 ```javascript
 const deploy = require('deploy-to-github-pages');
 
-deploy(options).catch(err => { console.log(err); })
+deploy(options).catch(err => {
+  console.log(err);
+});
 ```
 
 ### Options
 
-| Option      | flag  | description                                        | default    | env variable   | required | required in CI |
-|-------------|------:|----------------------------------------------------|------------|----------------|---------:|---------------:|
-| `directory` |    -d | directory you wish to deploy                       | `'public'` |                |        * |              * |
-| `token`     |    -t | [GitHub token](https://github.com/settings/tokens) |            | `GITHUB_TOKEN` |        * |              * |
-| `owner`     |    -o | GitHub repo owner/org                              |            |                |        * |                |
-| `repo`      |    -r | GitHub repo name                                   |            |                |        * |                |
-| `branch`    |    -b | branch name                                        | `'master'` |                |        * |                |
-| `buildUrl`  |    -u | link displayed when deployment fails               |            |                |          |                |
+| Option          | flag | description                                        | default    | env variable   | required | required in CI |
+| --------------- | ---: | -------------------------------------------------- | ---------- | -------------- | -------: | -------------: |
+| `directory`     |   -d | directory you wish to deploy                       | `'public'` |                |       \* |             \* |
+| `token`         |   -t | [GitHub token](https://github.com/settings/tokens) |            | `GITHUB_TOKEN` |       \* |             \* |
+| `owner`         |   -o | GitHub repo owner/org                              |            |                |       \* |                |
+| `repo`          |   -r | GitHub repo name                                   |            |                |       \* |                |
+| `branch`        |   -b | branch name                                        | `'master'` |                |       \* |                |
+| `buildUrl`      |   -u | link displayed when deployment fails               |            |                |          |                |
+| `defaultBranch` |      | Your github default branch                         | `'master'` |                |          |                |
 
 Therefore, if ran from CircleCI or GitHub Actions workflows with a `GITHUB_TOKEN` environment variable present and the directory to be deployed is named `public`, _no configuration options are needed_, so just the following is enough:
 
@@ -56,7 +59,9 @@ deploy-to-github-pages
 or
 
 ```javascript
-deploy().catch(err => { console.log(err); })
+deploy().catch(err => {
+  console.log(err);
+});
 ```
 
 ## Contributing

--- a/bin/deploy-to-github-pages.js
+++ b/bin/deploy-to-github-pages.js
@@ -15,6 +15,7 @@ async function main() {
     .option('-u, --build-url [build-url]', 'Link displayed when deployment fails')
     .option('--dotfiles', 'Include dotfiles')
     .option('--verbose', 'Log verbose information from gh-pages')
+    .option('--defaultBranch', 'Specify the default branch for your repo')
     .parse(process.argv);
 
   const options = cleanOptions({
@@ -26,6 +27,7 @@ async function main() {
     buildUrl: program.buildUrl,
     dotfiles: !!program.dotfiles,
     verbose: !!program.verbose,
+    defaulBranch: program.defaulBranch,
   });
 
   try {

--- a/lib/deployment/preparation/preparation.js
+++ b/lib/deployment/preparation/preparation.js
@@ -7,28 +7,34 @@ shell.set('-e');
 
 module.exports = { prepareDeployDirectory };
 
-function prepareDeployDirectory(deployDirectory, { directory: sourceDirectory, branch }) {
-  createBranchDirectoryIfNeeded(deployDirectory, branch);
+function prepareDeployDirectory(
+  deployDirectory,
+  { directory: sourceDirectory, branch, defaultBranch },
+) {
+  createBranchDirectoryIfNeeded(deployDirectory, branch, defaultBranch);
 
-  copyContentWithReplacement(sourceDirectory, getTargetDirectory(deployDirectory, branch));
+  copyContentWithReplacement(
+    sourceDirectory,
+    getTargetDirectory(deployDirectory, branch, defaultBranch),
+  );
 }
 
-function createBranchDirectoryIfNeeded(deployDirectory, branch) {
-  if (!isMaster(branch)) {
+function createBranchDirectoryIfNeeded(deployDirectory, branch, defaultBranch) {
+  if (!isDefaultBranch(branch, defaultBranch)) {
     shell.mkdir('-p', getBranchDirectory(deployDirectory));
   }
 }
 
-function isMaster(branch) {
-  return branch === 'master';
+function isDefaultBranch(branch, defaultBranch) {
+  return branch === defaultBranch;
 }
 
 function getBranchDirectory(deployDirectory) {
   return path.join(deployDirectory, BRANCH_DIRECTORY_NAME);
 }
 
-function getTargetDirectory(deployDirectory, branch) {
-  return isMaster(branch)
+function getTargetDirectory(deployDirectory, branch, defaultBranch) {
+  return isDefaultBranch(branch, defaultBranch)
     ? deployDirectory
     : path.join(getBranchDirectory(deployDirectory), branch);
 }

--- a/lib/deployment/preparation/preparation.js
+++ b/lib/deployment/preparation/preparation.js
@@ -20,13 +20,9 @@ function prepareDeployDirectory(
 }
 
 function createBranchDirectoryIfNeeded(deployDirectory, branch, defaultBranch) {
-  if (!isDefaultBranch(branch, defaultBranch)) {
+  if (branch !== defaultBranch) {
     shell.mkdir('-p', getBranchDirectory(deployDirectory));
   }
-}
-
-function isDefaultBranch(branch, defaultBranch) {
-  return branch === defaultBranch;
 }
 
 function getBranchDirectory(deployDirectory) {
@@ -34,7 +30,7 @@ function getBranchDirectory(deployDirectory) {
 }
 
 function getTargetDirectory(deployDirectory, branch, defaultBranch) {
-  return isDefaultBranch(branch, defaultBranch)
+  return branch === defaultBranch
     ? deployDirectory
     : path.join(getBranchDirectory(deployDirectory), branch);
 }

--- a/lib/deployment/preparation/preparation.spec.js
+++ b/lib/deployment/preparation/preparation.spec.js
@@ -41,27 +41,6 @@ describe('Preparation', () => {
     });
   });
 
-  describe('on a non-master branch with defaultbranch = non-master', () => {
-    const options = { directory: 'source', branch: 'not-master', defaultBranch: 'not-master' };
-
-    it('does not create branch directory', () => {
-      expect(shell.mkdir).not.toBeCalled();
-      prepareDeployDirectory('deploy-directory', options);
-      expect(shell.mkdir).not.toBeCalled();
-    });
-
-    it('removes deploy directory to allow copying with replacement', () => {
-      prepareDeployDirectory('deploy-directory', options);
-      expect(shell.rm).toBeCalledWith('-rf', 'deploy-directory');
-    });
-
-    it('moves content from source directory to deploy directory', () => {
-      expect(shell.cp).not.toBeCalled();
-      prepareDeployDirectory('deploy-directory', options);
-      expect(shell.cp).toBeCalledWith('-r', 'source', 'deploy-directory');
-    });
-  });
-
   describe('on a non-master branch', () => {
     const options = { directory: 'source', branch: 'not-master' };
 

--- a/lib/deployment/preparation/preparation.spec.js
+++ b/lib/deployment/preparation/preparation.spec.js
@@ -9,7 +9,7 @@ jest.mock('shelljs', () => ({
 }));
 jest.mock('path', () => ({ join: (...parts) => parts.join('/') }));
 
-const { prepareDeployDirectory } = require('./');
+const { prepareDeployDirectory } = require('.');
 
 describe('Preparation', () => {
   afterEach(jest.resetAllMocks);
@@ -21,7 +21,7 @@ describe('Preparation', () => {
   });
 
   describe('on master branch', () => {
-    const options = { directory: 'source', branch: 'master' };
+    const options = { directory: 'source', branch: 'master', defaultBranch: 'master' };
 
     it('does not create branch directory', () => {
       expect(shell.mkdir).not.toBeCalled();
@@ -30,7 +30,27 @@ describe('Preparation', () => {
     });
 
     it('removes deploy directory to allow copying with replacement', () => {
-      expect(shell.rm).not.toBeCalled();
+      prepareDeployDirectory('deploy-directory', options);
+      expect(shell.rm).toBeCalledWith('-rf', 'deploy-directory');
+    });
+
+    it('moves content from source directory to deploy directory', () => {
+      expect(shell.cp).not.toBeCalled();
+      prepareDeployDirectory('deploy-directory', options);
+      expect(shell.cp).toBeCalledWith('-r', 'source', 'deploy-directory');
+    });
+  });
+
+  describe('on a non-master branch with defaultbranch = non-master', () => {
+    const options = { directory: 'source', branch: 'not-master', defaultBranch: 'not-master' };
+
+    it('does not create branch directory', () => {
+      expect(shell.mkdir).not.toBeCalled();
+      prepareDeployDirectory('deploy-directory', options);
+      expect(shell.mkdir).not.toBeCalled();
+    });
+
+    it('removes deploy directory to allow copying with replacement', () => {
       prepareDeployDirectory('deploy-directory', options);
       expect(shell.rm).toBeCalledWith('-rf', 'deploy-directory');
     });

--- a/lib/options/options.js
+++ b/lib/options/options.js
@@ -17,7 +17,14 @@ function extendPassedOptions(options) {
 }
 
 function extendWithDefaultOptions(options) {
-  return { directory: 'public', branch: 'master', dotfiles: false, verbose: false, ...options };
+  return {
+    directory: 'public',
+    branch: 'master',
+    dotfiles: false,
+    verbose: false,
+    defaultBranch: 'master',
+    ...options,
+  };
 }
 
 function extendWithGithubTokenVariable(options) {

--- a/lib/options/options.js
+++ b/lib/options/options.js
@@ -20,9 +20,9 @@ function extendWithDefaultOptions(options) {
   return {
     directory: 'public',
     branch: 'master',
+    defaultBranch: 'master',
     dotfiles: false,
     verbose: false,
-    defaultBranch: 'master',
     ...options,
   };
 }

--- a/lib/options/options.spec.js
+++ b/lib/options/options.spec.js
@@ -1,9 +1,9 @@
-const { createOptions } = require('./');
+const { createOptions } = require('.');
 
 describe('Options', () => {
   beforeEach(cleanEnvironmentVariables);
 
-  it('extends passed options with default directory to deploy, master branch, and no dotfiles', () => {
+  it('extends passed options with default directory to deploy, master branch, defaultBranch master, and no dotfiles', () => {
     const options = {
       token: 'a-token',
       owner: 'an-owner',
@@ -13,6 +13,7 @@ describe('Options', () => {
       ...options,
       directory: 'public',
       branch: 'master',
+      defaultBranch: 'master',
       dotfiles: false,
       verbose: false,
     });
@@ -24,6 +25,7 @@ describe('Options', () => {
       owner: 'an-owner',
       repo: 'a-repo',
       branch: 'a-branch',
+      defaultBranch: 'a-branch',
       directory: 'a-directory',
       dotfiles: true,
       verbose: true,
@@ -38,6 +40,7 @@ describe('Options', () => {
       owner: 'an-owner',
       repo: 'a-repo',
       branch: 'a-branch',
+      defaultBranch: 'a-branch',
       directory: 'a-directory',
       dotfiles: true,
       verbose: true,
@@ -52,13 +55,14 @@ describe('Options', () => {
     process.env.CIRCLE_BRANCH = 'a-branch';
     process.env.CIRCLE_BUILD_URL = '/a-build-url';
 
-    const options = { token: 'a-token', directory: 'a-directory' };
+    const options = { token: 'a-token', directory: 'a-directory', defaultBranch: 'a-branch' };
 
     expect(createOptions(options)).toEqual({
       token: 'a-token',
       owner: 'an-owner',
       repo: 'a-repo',
       branch: 'a-branch',
+      defaultBranch: 'a-branch',
       buildUrl: '/a-build-url',
       directory: 'a-directory',
       dotfiles: false,
@@ -89,6 +93,7 @@ describe('Options', () => {
       directory: 'a-directory',
       dotfiles: false,
       verbose: false,
+      defaultBranch: 'master',
     });
 
     delete process.env.GITHUB_WORKFLOW;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deploy-to-github-pages",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "A Node library that makes deploying a directory on a branch to GitHub pages easy and automatic.",
   "bin": {
     "deploy-to-github-pages": "bin/deploy-to-github-pages.js"


### PR DESCRIPTION
- Add defaultBranch flag with `default = master`
- Allow users to specify a different default branch other than master branch
