### PR TITLE
chore: cleanup util

### DIFF
--- a/bin/deploy-to-github-pages.js
+++ b/bin/deploy-to-github-pages.js
@@ -1,8 +1,10 @@
 #! /usr/bin/env node
 const program = require('commander');
-const deploy = require('..');
+const { deploy, cleanup } = require('..');
 
 const { version } = require('../package.json');
+
+const BRANCH_DIRECTORY_NAME = 'branch';
 
 async function main() {
   program
@@ -14,6 +16,7 @@ async function main() {
     .option('-b, --branch [branch]', 'Branch name')
     .option('-u, --build-url [build-url]', 'Link displayed when deployment fails')
     .option('-m, --defaultBranch [defaultBranch]', 'Specify the default branch for your repo')
+    .option('-c, --clean [numOfDays]', 'Removes deployed folders older than numOfDays')
     .option('--dotfiles', 'Include dotfiles')
     .option('--verbose', 'Log verbose information from gh-pages')
     .parse(process.argv);
@@ -28,10 +31,16 @@ async function main() {
     defaultBranch: program.defaultBranch,
     dotfiles: !!program.dotfiles,
     verbose: !!program.verbose,
+    clean: !!program.clean,
+    BRANCH_DIRECTORY_NAME,
   });
 
   try {
+    const { clean, branch } = program;
     await deploy(options);
+    if (clean) {
+      await cleanup({ clean, branch, BRANCH_DIRECTORY_NAME });
+    }
   } catch (err) {
     console.log(err);
 

--- a/lib/cleanup/cleanup.js
+++ b/lib/cleanup/cleanup.js
@@ -1,0 +1,55 @@
+const { execSync } = require('child_process');
+const shell = require('shelljs');
+const glob = require('glob');
+const path = require('path');
+
+module.exports = cleanup;
+
+const execSyncWithMessage = ({ command, message }) => {
+  execSync(command, (err, output, stderr) => {
+    if (err) {
+      console.log(`error: ${err.message}`);
+      return;
+    }
+    if (stderr) {
+      console.log(`stderr: ${stderr}`);
+    }
+  });
+  console.log(message);
+};
+
+async function cleanup({ clean, branch, BRANCH_DIRECTORY_NAME }) {
+  const root = path.join(process.cwd(), `../../${BRANCH_DIRECTORY_NAME}/*`);
+
+  try {
+    if (branch !== 'gh-pages') {
+      execSyncWithMessage({
+        command: `git checkout gh-pages`,
+        message: `cleanup: checkout to gh-pages`,
+      });
+    }
+
+    const paths = glob.sync(root);
+
+    await Promise.all(
+      paths.map(branchPath => {
+        const gitModified = execSync(`git log -1 --format="%ad" -- ${branchPath}`).toString();
+        const differenceInTime = new Date().getTime() - new Date(gitModified).getTime();
+        const differenceInDays = Math.floor(differenceInTime / (1000 * 3600 * 24));
+
+        if (differenceInDays >= clean) {
+          console.log('removed folder', branchPath);
+          shell.rm('-rf', branchPath);
+        }
+        return true;
+      }),
+    );
+
+    execSyncWithMessage({
+      command: `git commit -am "chore: deploy-to-github-pages cleanup"`,
+      message: `cleanup: commit`,
+    });
+  } catch (err) {
+    console.log(err);
+  }
+}

--- a/lib/cleanup/index.js
+++ b/lib/cleanup/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./cleanup');

--- a/lib/deployment/preparation/preparation.js
+++ b/lib/deployment/preparation/preparation.js
@@ -1,17 +1,15 @@
 const shell = require('shelljs');
 const path = require('path');
 
-const BRANCH_DIRECTORY_NAME = 'branch';
-
 shell.set('-e');
 
 module.exports = { prepareDeployDirectory };
 
 function prepareDeployDirectory(
   deployDirectory,
-  { directory: sourceDirectory, branch, defaultBranch },
+  { directory: sourceDirectory, branch, defaultBranch, BRANCH_DIRECTORY_NAME },
 ) {
-  createBranchDirectoryIfNeeded(deployDirectory, branch, defaultBranch);
+  createBranchDirectoryIfNeeded(deployDirectory, branch, defaultBranch, BRANCH_DIRECTORY_NAME);
 
   copyContentWithReplacement(
     sourceDirectory,
@@ -19,13 +17,18 @@ function prepareDeployDirectory(
   );
 }
 
-function createBranchDirectoryIfNeeded(deployDirectory, branch, defaultBranch) {
+function createBranchDirectoryIfNeeded(
+  deployDirectory,
+  branch,
+  defaultBranch,
+  BRANCH_DIRECTORY_NAME,
+) {
   if (branch !== defaultBranch) {
-    shell.mkdir('-p', getBranchDirectory(deployDirectory));
+    shell.mkdir('-p', getBranchDirectory(deployDirectory, BRANCH_DIRECTORY_NAME));
   }
 }
 
-function getBranchDirectory(deployDirectory) {
+function getBranchDirectory(deployDirectory, BRANCH_DIRECTORY_NAME) {
   return path.join(deployDirectory, BRANCH_DIRECTORY_NAME);
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,1 +1,4 @@
-module.exports = require('./deploy');
+const deploy = require('./deploy');
+const cleanup = require('./cleanup');
+
+module.exports = { deploy, cleanup };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@octokit/rest": "^15.15.1",
     "commander": "^2.19.0",
     "gh-pages": "^2.0.1",
+    "glob": "^7.1.6",
     "shelljs": "^0.8.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2017,7 +2017,7 @@ glob-parent@^5.0.0, glob-parent@^5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==


### PR DESCRIPTION
## 🖼 Context

deploy-to-github-pages had no cleanup utils, that results in gh-pages branch to grow indefinitely slowing down the actual deploy to gh-pages

## 🚀 Changes

Add cleanup options -c which accepts a number. All branches older than number of days specified will be deleted

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
